### PR TITLE
Salvar cpf do contratante no banco sem formatação, apenas números [@suelengc]

### DIFF
--- a/app/models/contratante.rb
+++ b/app/models/contratante.rb
@@ -35,7 +35,7 @@ class Contratante < ActiveRecord::Base
 		cadastro.PNS?
 	end
 
-	def cpf= value
-		@cpf = value.remove('.').remove('-')
+	def cpf=(value)
+		write_attribute(:cpf, value.remove('.').remove('-'))
 	end
 end


### PR DESCRIPTION
A busca do contratante por cpf não não funciona se o cpf estiver formatado. Ou seja, temos que retirar a máscara do cpf antes de fazer a busca /contratante/cpf/12345678902

Porém, o cpf estava sendo salvo no banco com formatação, ou seja, ao buscar por 12345678902, ele não encontrava no banco pois, no banco existia 123.456.789-02. 

Logo, tínhamos duas opções, 1) reaplicar a máscara do cpf no backend antes de fazer a busca ou 2) remover a formatação antes de salvar o cpf no banco. Por diversas razões, optamos pela opção 2. 

Esta PR é justamente a implementação de salvar o cpf sem formatação.
